### PR TITLE
Fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@
 /vendor/
 /Godeps/
 
-
+.env
 # End of https://www.gitignore.io/api/go

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:e9a22e4d1f82d2b4b36e3cede2a1dfb41a798574ecf771b8d05e4d2ffe7c2a07"
+  name = "github.com/articulate/ohdear-sdk"
+  packages = ["ohdear"]
+  pruneopts = "UT"
+  revision = "bcf297a47a7a96f40ffc3b8f120db82be2013ac9"
+
+[[projects]]
   digest = "1:c590ed03a8431029a93eb0ff1645604964144c06623b97f5b4d4f64ac820dd46"
   name = "github.com/aws/aws-sdk-go"
   packages = [
@@ -396,14 +404,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7aefb397a53fc437c90f0fdb3e1419c751c5a3a165ced52325d5d797edf1aca6"
-  name = "github.com/moul/http2curl"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "9ac6cf4d929b2fa8fd2d2e6dec5bb0feb4f4911d"
-
-[[projects]]
   digest = "1:9ec6cf1df5ad1d55cf41a43b6b1e7e118a91bade4f68ff4303379343e40c0e25"
   name = "github.com/oklog/run"
   packages = ["."]
@@ -423,14 +423,6 @@
   pruneopts = "UT"
   revision = "dcda3199365ca2a5f24aea4c42aa56f6a197d117"
   version = "v1.1.2"
-
-[[projects]]
-  branch = "master"
-  digest = "1:716d9c73123eaf4c069491a840499334ce135917b6b612826977830621728d6b"
-  name = "github.com/smallnest/goreq"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "2e3372c80388e4b95c699c950eb2c9faba6c32e0"
 
 [[projects]]
   digest = "1:4aeb3860275fa1fd60cccfb5a6ef85da438bf17402e1e84412ade4d4b55066a0"
@@ -488,7 +480,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:68bde69dfc39fb337da197554ca7d453d7d9bf558e97eb3ad477a31c96755457"
+  digest = "1:57558ae9af42770158eb5584d9466101c965cd644b01d32dd15720da0a4a0286"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -498,10 +490,7 @@
     "http2",
     "http2/hpack",
     "idna",
-    "internal/socks",
     "internal/timeseries",
-    "proxy",
-    "publicsuffix",
     "trace",
   ]
   pruneopts = "UT"
@@ -587,13 +576,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/davecgh/go-spew/spew",
+    "github.com/articulate/ohdear-sdk/ohdear",
     "github.com/hashicorp/terraform/helper/acctest",
     "github.com/hashicorp/terraform/helper/resource",
     "github.com/hashicorp/terraform/helper/schema",
     "github.com/hashicorp/terraform/plugin",
     "github.com/hashicorp/terraform/terraform",
-    "github.com/smallnest/goreq",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Go Report Card](https://goreportcard.com/badge/github.com/articulate/terraform-provider-ohdear)](https://goreportcard.com/report/github.com/articulate/terraform-provider-ohdear)
 Terraform Provider OhDear
 ==================
 
@@ -27,17 +28,16 @@ You can specify the inputs in your tf plan:
 
 ```
 provider "ohdear" {
-  TODO = "TODO"
+  api_token = "XXXX"
+  api_url   = "https://ohdear.app"
 }
 ```
 
 OR you can specify environment variables:
 
-TODO Modify these:
 ```
-OHDEAR_ORG_NAME=<OhDear instance name, e.g. dev-XXXXXX>
-OHDEAR_API_TOKEN=<OhDear instance api token with the Administrator role>
-OHDEAR_BASE_URL=<OhDear base url, e.g. OhDearpreview.com>
+OHDEAR_API_TOKEN=<OhDear api token>
+OHDEAR_BASE_URL="https://ohdear.app"
 ```
 
 Building The Provider
@@ -71,11 +71,13 @@ Example terraform plan:
 
 ```
 provider "ohdear" {
-  TODO = "TODO"
+  api_token = "XXXX"
+  api_url   = "https://ohdear.app"
 }
 
-resource "ohdear_todo" "blah" {
-  TODO = "TODO"
+resource "ohdear_site" "fnord" {
+  team_id = 1337
+  url     = "https://site.iwanttomonitor.com"
 }
 ```
 

--- a/ohdear/config.go
+++ b/ohdear/config.go
@@ -1,7 +1,10 @@
 package ohdear
 
-import ()
+import "github.com/articulate/ohdear-sdk/ohdear"
 
 type Config struct {
-	Token string
+	apiToken string
+	baseURL  string
+
+	client *ohdear.Client
 }

--- a/ohdear/provider.go
+++ b/ohdear/provider.go
@@ -1,6 +1,7 @@
 package ohdear
 
 import (
+	"github.com/articulate/ohdear-sdk/ohdear"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -13,6 +14,11 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OHDEAR_TOKEN", nil),
 			},
+			"api_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OHDEAR_API_URL", nil),
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"ohdear_site": resourceOhdearSite(),
@@ -22,6 +28,17 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	config := Config{Token: d.Get("api_token").(string)}
-	return config, nil
+	apiToken := d.Get("api_token").(string)
+	baseURL := "https://ohdear.app"
+	client, err := ohdear.NewClient(baseURL, apiToken)
+	if err != nil {
+		return nil, err
+	}
+
+	config := Config{
+		apiToken: apiToken,
+		baseURL:  baseURL,
+		client:   client,
+	}
+	return &config, err
 }

--- a/ohdear/resource_site.go
+++ b/ohdear/resource_site.go
@@ -18,18 +18,19 @@ func resourceOhdearSite() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceSiteCreate,
 		Read:   resourceSiteRead,
-		Update: resourceSiteUpdate,
 		Delete: resourceSiteDelete,
 		Exists: resourceSiteExists,
 		Schema: map[string]*schema.Schema{
 			"url": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "URL of the site to be checked",
 			},
 			"team_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "ID of the team for this site",
 			},
 		},
@@ -77,10 +78,6 @@ func resourceSiteCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	return resourceSiteRead(d, m)
-}
-
-func resourceSiteUpdate(d *schema.ResourceData, m interface{}) error {
-	return nil
 }
 
 func resourceSiteRead(d *schema.ResourceData, m interface{}) error {

--- a/ohdear/resource_site.go
+++ b/ohdear/resource_site.go
@@ -1,26 +1,25 @@
 package ohdear
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
+	"io/ioutil"
+	"log"
 
+	"github.com/articulate/ohdear-sdk/ohdear"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/smallnest/goreq"
 )
-
-type Site struct {
-	Url    string `json:"url"`
-	TeamId string `json:"team_id"`
-}
 
 func resourceOhdearSite() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceSiteCreate,
-		Read:   resourceSiteRead,
-		Delete: resourceSiteDelete,
-		Exists: resourceSiteExists,
+		Create: resourceOhdearSiteCreate,
+		Read:   resourceOhdearSiteRead,
+		Delete: resourceOhdearSiteDelete,
 		Schema: map[string]*schema.Schema{
+			"site_id": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Primary Key of the site",
+			},
 			"url": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -28,7 +27,7 @@ func resourceOhdearSite() *schema.Resource {
 				Description: "URL of the site to be checked",
 			},
 			"team_id": &schema.Schema{
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Required:    true,
 				ForceNew:    true,
 				Description: "ID of the team for this site",
@@ -37,76 +36,61 @@ func resourceOhdearSite() *schema.Resource {
 	}
 }
 
-func resourceSiteExists(d *schema.ResourceData, m interface{}) (bool, error) {
-	_, _, err := goreq.New().Get("https://ohdear.app/api/sites").
-		SetHeader("Authorization", "Bearer "+m.(Config).Token).
-		SetHeader("Accept", "application/json").
-		SetHeader("Content-Type", "application/json").
-		End()
-
-	if err == nil {
-		return true, nil
-	} else {
-		return false, nil
+func resourceOhdearSiteExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*Config).client
+	log.Printf("[DEBUG] Calling Exists lifecycle function for site %v\n", d.Id)
+	if _, _, err := client.SiteService.GetSite(d.Get("site_id").(int)); err != nil {
+		return false, err
 	}
+
+	return true, nil
 }
 
-func resourceSiteCreate(d *schema.ResourceData, m interface{}) error {
-	newSite := Site{
+func resourceOhdearSiteCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Calling Create lifecycle function for site %v\n", d.Id)
+	site := &ohdear.Site{
 		Url:    d.Get("url").(string),
-		TeamId: d.Get("team_id").(string),
+		TeamId: d.Get("team_id").(int),
 	}
 
-	encoded, _ := json.Marshal(newSite)
+	newSite, _, err := meta.(*Config).client.SiteService.CreateSite(site)
 
-	_, body, _ := goreq.New().Post("https://ohdear.app/api/sites").
-		SetHeader("Authorization", "Bearer "+m.(Config).Token).
-		SetHeader("Accept", "application/json").
-		SetHeader("Content-Type", "application/json").
-		SendRawString(string(encoded)).
-		End()
-
-	var datai interface{}
-	err := json.Unmarshal([]byte(body), &datai)
-	data, _ := datai.(map[string]interface{})
-
-	if err == nil {
-		s := fmt.Sprintf("%f", data["id"].(float64))
-		d.SetId(s)
-	} else {
-		fmt.Println(err)
+	if err != nil {
+		return fmt.Errorf("error creating site: %s", err.Error())
 	}
 
-	return resourceSiteRead(d, m)
+	d.Set("site_id", newSite.Id)
+	d.SetId(d.Get("url").(string))
+	return resourceOhdearSiteRead(d, meta)
 }
 
-func resourceSiteRead(d *schema.ResourceData, m interface{}) error {
-	resp, body, err := goreq.New().Get("https://ohdear.app/api/sites/"+d.Id()).
-		SetHeader("Authorization", "Bearer "+m.(Config).Token).
-		SetHeader("Accept", "application/json").
-		SetHeader("Content-Type", "application/json").
-		End()
+func resourceOhdearSiteRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Calling Read lifecycle function for site %v\n", d.Id)
+	id := d.Get("site_id").(int)
+	newSite, resp, err := meta.(*Config).client.SiteService.GetSite(id)
 
-	var datai interface{}
-	_ = json.Unmarshal([]byte(body), &datai)
-	data, _ := datai.(map[string]interface{})
+	defer resp.Body.Close()
 
-	if err == nil && resp.Status == "200 OK" {
-		d.Set("team_id", strconv.Itoa(int(data["team_id"].(float64))))
-		d.Set("url", data["url"].(string))
+	htmlData, err := ioutil.ReadAll(resp.Body)
+	log.Printf("[DEBUG] Response from Ohdear API: %s", string(htmlData))
+	if err != nil {
+		return fmt.Errorf("Error reading Site: %s", err.Error())
 	}
+
+	d.Set("url", newSite.Url)
+	d.Set("team_id", newSite.TeamId)
 
 	return nil
 }
 
-func resourceSiteDelete(d *schema.ResourceData, m interface{}) error {
-	resp, _, _ := goreq.New().Delete("https://ohdear.app/api/sites/"+d.Id()).
-		SetHeader("Authorization", "Bearer "+m.(Config).Token).
-		SetHeader("Accept", "application/json").
-		SetHeader("Content-Type", "application/json").
-		End()
+func resourceOhdearSiteUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceOhdearSiteRead(d, meta)
+}
 
-	fmt.Println(&resp)
+func resourceOhdearSiteDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Calling Delete lifecycle function for site %v\n", d.Id)
+	id := d.Get("site_id").(int)
 
-	return nil
+	_, err := meta.(*Config).client.SiteService.DeleteSite(id)
+	return err
 }

--- a/ohdear/resource_site_test.go
+++ b/ohdear/resource_site_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
+func TestAccOhdearSiteCreate(t *testing.T) {
+	ri := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfigForOhdearSiteCreate(ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "team_id", "1820"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "url", fmt.Sprintf("http://www.test-%d.com", ri)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOhdearSiteLifecycle(t *testing.T) {
 	ri := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
@@ -16,12 +32,14 @@ func TestAccOhdearSiteLifecycle(t *testing.T) {
 			{
 				Config: testConfigForOhdearSiteCreate(ri),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "team_id", "1775"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "team_id", "1820"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "url", fmt.Sprintf("http://www.test-%d.com", ri)),
 				),
 			},
 			{
 				Config: testConfigForOhdearSiteUpdate(ri),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "team_id", "1820"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "url", fmt.Sprintf("http://updated.test-%d.com", ri)),
 				),
 			},
@@ -32,7 +50,7 @@ func TestAccOhdearSiteLifecycle(t *testing.T) {
 func testConfigForOhdearSiteCreate(rInt int) string {
 	return fmt.Sprintf(`
 resource "ohdear_site" "test-%d" {
-  team_id  = "1775"
+  team_id  = 1820
   url      = "http://www.test-%d.com"
 }
 `, rInt, rInt)
@@ -41,7 +59,7 @@ resource "ohdear_site" "test-%d" {
 func testConfigForOhdearSiteUpdate(rInt int) string {
 	return fmt.Sprintf(`
 resource "ohdear_site" "test-%d" {
-  team_id  = "1775"
+  team_id  = 1820
   url      = "http://updated.test-%d.com"
 }`, rInt, rInt)
 }

--- a/ohdear/resource_site_test.go
+++ b/ohdear/resource_site_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOhdearSiteCreate(t *testing.T) {
+func TestAccOhdearSiteLifecycle(t *testing.T) {
 	ri := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
@@ -17,6 +17,12 @@ func TestAccOhdearSiteCreate(t *testing.T) {
 				Config: testConfigForOhdearSiteCreate(ri),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "team_id", "1775"),
+				),
+			},
+			{
+				Config: testConfigForOhdearSiteUpdate(ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf("ohdear_site.test-%d", ri), "url", fmt.Sprintf("http://updated.test-%d.com", ri)),
 				),
 			},
 		},
@@ -30,4 +36,12 @@ resource "ohdear_site" "test-%d" {
   url      = "http://www.test-%d.com"
 }
 `, rInt, rInt)
+}
+
+func testConfigForOhdearSiteUpdate(rInt int) string {
+	return fmt.Sprintf(`
+resource "ohdear_site" "test-%d" {
+  team_id  = "1775"
+  url      = "http://updated.test-%d.com"
+}`, rInt, rInt)
 }


### PR DESCRIPTION
Uses `articulate/ohdear-sdk` instead of `Goreq` for requests. 

Adds basic info (and a badge!) to README.

Updates deps.