### PR TITLE
only turn on mixed content check by default for https sites

### DIFF
--- a/internal/provider/resource_site.go
+++ b/internal/provider/resource_site.go
@@ -102,7 +102,7 @@ func resourceOhdearSiteDiff(_ context.Context, d *schema.ResourceDiff, meta inte
 			"broken_links":             true,
 			"certificate_health":       isHTTPS,
 			"certificate_transparency": isHTTPS,
-			"mixed_content":            true,
+			"mixed_content":            isHTTPS,
 			"performance":              true,
 		})
 

--- a/internal/provider/resource_site_test.go
+++ b/internal/provider/resource_site_test.go
@@ -145,6 +145,34 @@ func TestAccOhdearSite_TeamID(t *testing.T) {
 	})
 }
 
+func TestAccOhdearSite_HTTPDefaults(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	url := fmt.Sprintf("http://example.com/%s", name)
+	resourceName := fmt.Sprintf("ohdear_site.%s", name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IDRefreshName:     resourceName,
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSiteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccOhdearSiteConfigBasic(name, url),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "checks.0.uptime", "true"),
+					resource.TestCheckResourceAttr(resourceName, "checks.0.broken_links", "true"),
+					resource.TestCheckResourceAttr(resourceName, "checks.0.certificate_health", "false"),
+					resource.TestCheckResourceAttr(resourceName, "checks.0.certificate_transparency", "false"),
+					resource.TestCheckResourceAttr(resourceName, "checks.0.mixed_content", "false"),
+					resource.TestCheckResourceAttr(resourceName, "checks.0.performance", "true"),
+				),
+			},
+		},
+	})
+}
+
 // Checks
 
 func doesSiteExists(strID string) (bool, error) {


### PR DESCRIPTION
Mixed content is another https only check, so only enable it on https sites by default.

## TODO

* [x] Add a test checking https default checks