### PR TITLE
Add missing DNS check

### DIFF
--- a/internal/provider/resource_site.go
+++ b/internal/provider/resource_site.go
@@ -74,6 +74,11 @@ func resourceOhdearSite() *schema.Resource {
 							Description: "Enable performance checks.",
 							Optional:    true,
 						},
+						"dns": {
+							Type:        schema.TypeBool,
+							Description: "Enable DNS checks.",
+							Optional:    true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
When trying to `terraform import` a site we get the following:

```
│ Error: Invalid address to set: []string{"checks", "0", "dns"}
```

I think this may fix it, only thing I'm not 100% sure about is whether or not something should be added to `resourceOhdearSiteDiff`.

A release with this would be greatly appreciated, as it's a blocker for us.