### PR TITLE
style(provider): replace unused params for ctx and t

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -59,7 +59,7 @@ func New() *schema.Provider {
 	}
 }
 
-func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	ua := fmt.Sprintf(
 		"terraform-provider-ohdear/%s (https://github.com/articulate/terraform-provider-ohdear)",
 		runtime.Version,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -30,7 +30,7 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-func TestProvider_impl(t *testing.T) {
+func TestProvider_impl(_ *testing.T) {
 	var _ schema.Provider = *New()
 }
 

--- a/internal/provider/resource_site.go
+++ b/internal/provider/resource_site.go
@@ -141,7 +141,7 @@ func resourceOhdearSiteCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceOhdearSiteRead(ctx, d, meta)
 }
 
-func resourceOhdearSiteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOhdearSiteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Calling Read lifecycle function for site %s\n", d.Id())
 
 	id, err := getSiteID(d)
@@ -171,7 +171,7 @@ func resourceOhdearSiteRead(ctx context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceOhdearSiteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOhdearSiteDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Calling Delete lifecycle function for site %s\n", d.Id())
 
 	id, err := getSiteID(d)

--- a/pkg/ohdear/error.go
+++ b/pkg/ohdear/error.go
@@ -25,7 +25,7 @@ func (e Error) Error() string {
 	return fmt.Sprintf("%d: %s", e.Response.StatusCode(), e.Response.Status())
 }
 
-func errorFromResponse(c *resty.Client, r *resty.Response) error {
+func errorFromResponse(_ *resty.Client, r *resty.Response) error {
 	if !r.IsError() {
 		return nil
 	}


### PR DESCRIPTION
Fixing linting errors that have shown up in recent dependabot upgrades.

Ran `golangci-lint run` locally after making the edits to confirm no existing errors.

[ERROR LINK](https://github.com/articulate/terraform-provider-ohdear/actions/runs/4582325121/jobs/8092480727?pr=84#step:4:28)