### PR TITLE
docs(README): update required go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ resource "ohdear_site" "test" {
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads.html) >= 0.12.x
-* [Go](https://golang.org/doc/install) 1.17 (for development)
+* [Go](https://golang.org/doc/install) 1.19 (for development)


### PR DESCRIPTION
Does what it says on the tin; updates the required go version to match what we are actually requiring here: https://github.com/articulate/terraform-provider-ohdear/blob/8f5f25fb83059cebc08119164803036f8e2254f1/go.mod#L3