### PR TITLE
style(golangci-lint): ignore perfsprint check for consistency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - sqlclosecheck
     - maligned
     - wrapcheck
+    - perfsprint
 
 issues:
   exclude-rules:

--- a/pkg/ohdear/client.go
+++ b/pkg/ohdear/client.go
@@ -25,7 +25,7 @@ func NewClient(baseURL, token string) *Client {
 	client.SetRetryCount(3)
 	client.SetRetryWaitTime(5 * time.Second)
 	client.SetRetryMaxWaitTime(20 * time.Second)
-	client.AddRetryCondition(func(r *resty.Response, err error) bool {
+	client.AddRetryCondition(func(r *resty.Response, _ error) bool {
 		return r.StatusCode() == http.StatusTooManyRequests
 	})
 


### PR DESCRIPTION
Includes a minor unused argument clarification.

Changes recommended by latest versions of golangci-lint