### PR TITLE
style(lint): address perfsprint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
-        - goerr113
+        - err113
 
 linters-settings:
   gocyclo:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,7 +23,7 @@ func init() {
 			desc += fmt.Sprintf(" Defaults to `%v`.", s.Default)
 		}
 		if s.Deprecated != "" {
-			desc += fmt.Sprintf(" __Deprecated__: %s", s.Deprecated)
+			desc += " __Deprecated__: " + s.Deprecated
 		}
 		return strings.TrimSpace(desc)
 	}

--- a/internal/provider/resource_site_test.go
+++ b/internal/provider/resource_site_test.go
@@ -24,9 +24,9 @@ func init() {
 
 func TestAccOhdearSite(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
-	url := fmt.Sprintf("https://example.com/%s", name)
-	resourceName := fmt.Sprintf("ohdear_site.%s", name)
-	updatedURL := fmt.Sprintf("%s/new", url)
+	url := "https://example.com/" + name
+	resourceName := "ohdear_site." + name
+	updatedURL := url + "/new"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -74,8 +74,8 @@ func TestAccOhdearSite(t *testing.T) {
 
 func TestAccOhdearSite_EnableDisableChecks(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
-	url := fmt.Sprintf("https://example.com/%s", name)
-	resourceName := fmt.Sprintf("ohdear_site.%s", name)
+	url := "https://example.com/" + name
+	resourceName := "ohdear_site." + name
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -125,8 +125,8 @@ func TestAccOhdearSite_EnableDisableChecks(t *testing.T) {
 
 func TestAccOhdearSite_TeamID(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
-	url := fmt.Sprintf("https://example.com/%s", name)
-	resourceName := fmt.Sprintf("ohdear_site.%s", name)
+	url := "https://example.com/" + name
+	resourceName := "ohdear_site." + name
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -156,8 +156,8 @@ func TestAccOhdearSite_TeamID(t *testing.T) {
 
 func TestAccOhdearSite_HTTPDefaults(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
-	url := fmt.Sprintf("http://example.com/%s", name)
-	resourceName := fmt.Sprintf("ohdear_site.%s", name)
+	url := "http://example.com/" + name
+	resourceName := "ohdear_site." + name
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/pkg/ohdear/client.go
+++ b/pkg/ohdear/client.go
@@ -25,7 +25,7 @@ func NewClient(baseURL, token string) *Client {
 	client.SetRetryCount(3)
 	client.SetRetryWaitTime(5 * time.Second)
 	client.SetRetryMaxWaitTime(20 * time.Second)
-	client.AddRetryCondition(func(r *resty.Response, err error) bool {
+	client.AddRetryCondition(func(r *resty.Response, _ error) bool {
 		return r.StatusCode() == http.StatusTooManyRequests
 	})
 


### PR DESCRIPTION
When doing simple string joins, the recommendation is to use concat instead of sprintf