### PR TITLE
ci(dependabot): set commit prefix to support release process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      include: scope
+      prefix: ci
     groups:
       actions:
         patterns:
@@ -13,6 +16,10 @@ updates:
     open-pull-requests-limit: 25
     schedule:
       interval: monthly
+    commit-message:
+      include: scope
+      prefix: deps
+      prefix-development: chore
     groups:
       terraform:
         patterns:


### PR DESCRIPTION
Our upcoming release process will be expecting specific commit prefixes to determine if it should attempt to create a release or not