### PR TITLE
test: testifylint fix for encoded-compare

### DIFF
--- a/pkg/ohdear/site_test.go
+++ b/pkg/ohdear/site_test.go
@@ -60,7 +60,7 @@ func TestAddSite(t *testing.T) {
 		func(req *http.Request) (*http.Response, error) {
 			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
-			assert.Equal(
+			assert.JSONEq(
 				t,
 				`{"checks":["uptime","performance","broken_links"],"team_id":5678,"url":"https://example.com/new"}`,
 				string(body),


### PR DESCRIPTION
Applying testifylint recommendation to use JSONEq for encoded compare.

```
  Error: pkg/ohdear/site_test.go:63:4: encoded-compare: use assert.JSONEq (testifylint)
  			assert.Equal(
  			^

  Error: issues found
```
- Fixes [failing test as seen here](https://github.com/articulate/terraform-provider-ohdear/actions/runs/11827183177/job/32954793690).
- This was [passing with golangci-lint v1.61.0](https://github.com/articulate/terraform-provider-ohdear/actions/runs/11522940965/job/32079874824#step:4:29), but fails with v1.62.0.