### PR TITLE
ci(test): grab latest releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @articulate/devex-sre
+* @articulate/devex

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,8 @@ jobs:
                 minor: .semver.minor | tonumber,
                 patch: .semver.patch | tonumber
             }
-          ] | group_by(.group) | [ .[] | sort_by(.patch) | .[-1] | .version ] | sort | .[-2:]')" >> "$GITHUB_OUTPUT"
+          ] | group_by(.group) | [ .[] | sort_by(.patch) | .[-1] | .version ] |
+          sort_by(.|split(".")|map(tonumber)) | .[-2:]')" >> "$GITHUB_OUTPUT"
     outputs:
       terraform: ${{ steps.versions.outputs.terraform }}
 


### PR DESCRIPTION
Since 1.10 was released this week, it wasn't sorting correctly and grabbing that version. Change the sort method to sort by split semver