### PR TITLE
ci(goreleaser): use existing draft

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -25,6 +25,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       - uses: goreleaser/goreleaser-action@v6
         with:
+          version: nightly
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,3 +42,5 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
+release:
+  use_existing_draft: true


### PR DESCRIPTION
Use goreleaser nightly which has a use_existing_draft option that will use the draft created by release please