### PR TITLE
build(go): use latest 1.23

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -25,7 +25,6 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: nightly
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/articulate/terraform-provider-ohdear
 
-go 1.23.0
+go 1.23
 
 require (
 	github.com/go-resty/resty/v2 v2.16.2


### PR DESCRIPTION
Drop the patch version and use the latest 1.23 version in our builds