### PR TITLE
feat: upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,12 +3,12 @@ name: Test
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - "README.md"
   push:
     branches:
       - main
     paths-ignore:
-      - 'README.md'
+      - "README.md"
 
 jobs:
   build:
@@ -32,7 +32,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
           cache: true
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
 
   versions:
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,32 +1,74 @@
+version: "2"
 linters:
-  presets:
-    - bugs
-    - error
-    - performance
   enable:
-    - gofmt
-    - gofumpt
-    - revive
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - durationcheck
+    - err113
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - fatcontext
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - gocyclo
-    - misspell
-    - whitespace
-    - goimports
     - gosec
+    - gosmopolitan
     - lll
+    - loggercheck
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - nilnesserr
+    - noctx
+    - prealloc
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - spancheck
+    - testifylint
+    - whitespace
+    - zerologlint
   disable:
+    - perfsprint
     - rowserrcheck
     - sqlclosecheck
     - wrapcheck
-    - perfsprint
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - err113
-
-linters-settings:
-  gocyclo:
-    min-complexity: 10
-  goimports:
-    local-prefixes: github.com/articulate/terraform-provider-ohdear
+  settings:
+    gocyclo:
+      min-complexity: 10
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - err113
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/articulate/terraform-provider-ohdear
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -31,7 +31,7 @@ func TestProvider(t *testing.T) {
 }
 
 func TestProvider_impl(_ *testing.T) {
-	var _ schema.Provider = *New()
+	var _ schema.Provider = *New() //nolint:staticcheck
 }
 
 func testAccPreCheck(t *testing.T) {


### PR DESCRIPTION
Added the ignore as it wanted to drop the variable type of the left hand side while we were specifically trying to test the implementation.