### PR TITLE
build(golang): upgrade to go 1.24

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
     - revive
     - spancheck
     - testifylint
+    - usetesting
     - whitespace
     - zerologlint
   disable:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/articulate/terraform-provider-ohdear
 
-go 1.23
+go 1.24
 
 require (
 	github.com/go-resty/resty/v2 v2.16.5

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -42,7 +41,7 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("OHDEAR_TEAM_ID must be set for acceptance tests")
 	}
 
-	diags := testAccProvider.Configure(context.TODO(), terraform.NewResourceConfigRaw(nil))
+	diags := testAccProvider.Configure(t.Context(), terraform.NewResourceConfigRaw(nil))
 	if diags.HasError() {
 		t.Fatal(diags[0].Summary)
 	}

--- a/pkg/ohdear/checks_test.go
+++ b/pkg/ohdear/checks_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestEnableCheck(t *testing.T) {
 	_, reset := mocklog()
-	defer reset()
-	defer httpmock.DeactivateAndReset()
+	t.Cleanup(reset)
+	t.Cleanup(httpmock.DeactivateAndReset)
 
 	resp, err := httpmock.NewJsonResponder(200, map[string]interface{}{"id": 1234})
 	require.NoError(t, err)
@@ -25,8 +25,8 @@ func TestEnableCheck(t *testing.T) {
 
 func TestDisableCheck(t *testing.T) {
 	_, reset := mocklog()
-	defer reset()
-	defer httpmock.DeactivateAndReset()
+	t.Cleanup(reset)
+	t.Cleanup(httpmock.DeactivateAndReset)
 
 	resp, err := httpmock.NewJsonResponder(200, map[string]interface{}{"id": 4321})
 	require.NoError(t, err)

--- a/pkg/ohdear/client_test.go
+++ b/pkg/ohdear/client_test.go
@@ -98,8 +98,8 @@ func TestClient(t *testing.T) {
 
 func TestSetUserAgent(t *testing.T) {
 	_, reset := mocklog()
-	defer reset()
-	defer httpmock.DeactivateAndReset()
+	t.Cleanup(reset)
+	t.Cleanup(httpmock.DeactivateAndReset)
 
 	httpmock.RegisterResponder("GET", "https://ohdear.test/ping",
 		func(req *http.Request) (*http.Response, error) {

--- a/pkg/ohdear/error_test.go
+++ b/pkg/ohdear/error_test.go
@@ -46,8 +46,8 @@ func TestError(t *testing.T) {
 
 func TestErrorFromResponse(t *testing.T) {
 	_, reset := mocklog()
-	defer reset()
-	defer httpmock.DeactivateAndReset()
+	t.Cleanup(reset)
+	t.Cleanup(httpmock.DeactivateAndReset)
 
 	resp, err := httpmock.NewJsonResponder(404, map[string]interface{}{"message": "Not found"})
 	require.NoError(t, err)

--- a/pkg/ohdear/logger_test.go
+++ b/pkg/ohdear/logger_test.go
@@ -22,7 +22,7 @@ func mocklog() (*bytes.Buffer, func()) {
 func TestTerraformLogger(t *testing.T) {
 	logger := &TerraformLogger{}
 	out, reset := mocklog()
-	defer reset()
+	t.Cleanup(reset)
 
 	logger.Errorf("test error message")
 	assert.Contains(t, out.String(), "[ERROR] test error message\n", out.String())

--- a/pkg/ohdear/site_test.go
+++ b/pkg/ohdear/site_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestGetSite(t *testing.T) {
 	_, reset := mocklog()
-	defer reset()
-	defer httpmock.DeactivateAndReset()
+	t.Cleanup(reset)
+	t.Cleanup(httpmock.DeactivateAndReset)
 
 	resp, err := httpmock.NewJsonResponder(200, map[string]interface{}{
 		"id":      1234,
@@ -53,8 +53,8 @@ func TestGetSite(t *testing.T) {
 
 func TestAddSite(t *testing.T) {
 	_, reset := mocklog()
-	defer reset()
-	defer httpmock.DeactivateAndReset()
+	t.Cleanup(reset)
+	t.Cleanup(httpmock.DeactivateAndReset)
 
 	httpmock.RegisterResponder("POST", "https://ohdear.test/api/sites",
 		func(req *http.Request) (*http.Response, error) {
@@ -91,8 +91,8 @@ func TestAddSite(t *testing.T) {
 
 func TestRemoveSite(t *testing.T) {
 	_, reset := mocklog()
-	defer reset()
-	defer httpmock.DeactivateAndReset()
+	t.Cleanup(reset)
+	t.Cleanup(httpmock.DeactivateAndReset)
 
 	httpmock.RegisterResponder("DELETE", "https://ohdear.test/api/sites/1234", httpmock.NewStringResponder(204, ""))
 


### PR DESCRIPTION
Upgrade to latest go.

Add usetesting linter and use t.Context instead of context.TODO.

Use t.Cleanup instead of defer